### PR TITLE
Breathing - Fix 1% chance of Tamponade occuring even when the Tampona…

### DIFF
--- a/addons/breathing/functions/fnc_woundsHandlerPulmoHit.sqf
+++ b/addons/breathing/functions/fnc_woundsHandlerPulmoHit.sqf
@@ -77,7 +77,7 @@ _unit setVariable [QGVAR(activeChestSeal), false, true];
 // Check for tamponade
 
 // Unit already has it or got lucky
-if ((_unit getVariable [QEGVAR(circulation,effusion), 0]) != 0 || floor (random 100) > EGVAR(circulation,tamponadeChance)) exitWith {_this};
+if ((_unit getVariable [QEGVAR(circulation,effusion), 0]) != 0 || floor (random 100) >= EGVAR(circulation,tamponadeChance)) exitWith {_this};
 
 [_unit] call FUNC(createTamponade);
 


### PR DESCRIPTION
…de Chance is set to 0% (#822)

Stops the 1% chance of Tamponade occuring even when the Tamponade Chance is set to 0%.

Tamponade can currently occur whenever `floor (random 100)` generates a 0, as the check is ">" instead of ">="

**When merged this pull request will:**
- _Describe what this pull request will do_
- _Each change in a separate line_

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
